### PR TITLE
fix: replace BrowserRouter by HashRouter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
@@ -7,9 +7,9 @@ import App from "./App";
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <BrowserRouter basename={process.env.PUBLIC_URL}>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
Hi,

the direct loading of subpages would be possible if BrowserRouter is replaced by HashRouter. 

Here is a test deployment: https://gros-pataplouf.github.io/Tech-Risers-Women.github.io/

The drawback is obviously the ugly url structure with the # inserted before the subpage name.  

Thanks for reviewing!
