### PR TITLE
fix: define closeNavbar function as prop in Navbar.jsx

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -42,6 +42,8 @@ function Navbar() {
 								title: 'Code of Conduct'
 							}
 						]}
+						closeNavbar={() => null}
+
 					/>
 				</li>
 
@@ -63,6 +65,8 @@ function Navbar() {
 							}
 						]}
 						inHamburger={false}
+						closeNavbar={() => null}
+
 					/>
 				</li>
 				{/* <li>


### PR DESCRIPTION
Added closeNavbar={() => null} as a prop passed to Dropdown Nav to avoid uncaught exception due to closeNavbar not being able to be destructured out of props in DropdownNav.jsx in Desktop version. Quick fix, needs refactoring.